### PR TITLE
Example of ImageLoader with KVO; fix For Cache usage in ImageLoader

### DIFF
--- a/GithubUsersRx/CellViewModel.swift
+++ b/GithubUsersRx/CellViewModel.swift
@@ -11,19 +11,21 @@ import UIKit
 
 class CellViewModel {
     
+    private let imageLoader = ImageLoader()
+    private(set) lazy var imageDownloadProgress = imageLoader.progress
+    
     private(set) var username: String
     private(set) var id: String
-    private(set) var imageUrl: URL
-    
+    private var imageUrl: URL
     
     init(forUser user: User) {
         self.username = user.login
         self.id = String(user.id)
         self.imageUrl = URL(string: user.avatarURL)!
-    }        
-    
-    func getProgress() -> Observable<ImageDownloadObservable?> {
-        return ImageLoader.shared.getDownloadProgress(from: imageUrl)
     }
     
+    func downloadImage() -> Observable<UIImage> {
+        return imageLoader.getImage(from: imageUrl)
+    }
+
 }

--- a/GithubUsersRx/TableViewCell.swift
+++ b/GithubUsersRx/TableViewCell.swift
@@ -31,24 +31,26 @@ class TableViewCell: UITableViewCell {
         name.text = vm.username
         idLabel.text = vm.id
         
-        checkProgress()
+        downloadImage()
     }
     
-    private func checkProgress() {
-        viewModel?.getProgress()
+    private func downloadImage() {
+        viewModel?.downloadImage()
             .observe(on: MainScheduler())
-            .subscribe(onNext: { [weak self] imageObservable in
-                if let image = imageObservable?.image {
-                    self?.avatarImage.image = image
-                    self?.progressLabel.isHidden = true
-                } else {
-                    imageObservable?.progress
-                        .observe(on: MainScheduler())
-                        .subscribe(onNext: { progress in                            
-                            self?.progressLabel.text = String(progress ?? 0)
-                        }).disposed(by: self!.bag)
-                }
-            }).disposed(by: bag)
+            .subscribe(onNext: { [weak self] image in
+                self?.progressLabel.isHidden = true
+                self?.avatarImage.image = image
+            })
+            .disposed(by: bag)
+        
+        
+        viewModel?.imageDownloadProgress
+            .observe(on: MainScheduler())
+            .subscribe(onNext: { [weak self] progress in
+                self?.progressLabel.text = String(describing: progress)
+            })
+            .disposed(by: bag)
+            
     }
     
 }


### PR DESCRIPTION
1) An example of how KVO can be reused into Rx (Progress translation into PublishSubject)
2) Fix of incorrect cache usage (cache shouldn't be created for every cell, it should be shared across them)